### PR TITLE
Add action to automatically check for new NP probes

### DIFF
--- a/.github/workflows/check_for_new_probes.yml
+++ b/.github/workflows/check_for_new_probes.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10' 
-          cache: 'pip' # Caches dependencies to speed up future runs
 
       #  Clone dev version of probeinterface
       - name: Clone external repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,0 @@
-[project]
-name = "probeinterface-library"
-version = "0.1.0"
-description = "Add your description here"
-readme = "README.md"
-requires-python = ">=3.9"
-dependencies = []


### PR DESCRIPTION
Adds a new weekly github action which generates the NP library from probeinterface. If there are any new probes, it automatically adds these to the repo and creates a PR.

See an example PR here: https://github.com/chrishalcrow/probeinterface_library/pull/4