### PR TITLE
Use released probeinterface version for update actions and tests (JSON-schema)

### DIFF
--- a/.github/workflows/check_for_changes_in_NP_jsons.yml
+++ b/.github/workflows/check_for_changes_in_NP_jsons.yml
@@ -24,18 +24,14 @@ jobs:
         with:
           python-version: '3.10' 
 
-      # we just the release probeinterface to get the version number
+      # we use the released probeinterface, cloned so that the generation
+      # scripts under resources/ are available as well
       - name: Install probeinterface and matplotlib
         run: |
-          pip install probeinterface matplotlib
-          PROBEINTERFACE_VERSION=$(pip show probeinterface | grep Version | awk '{print $2}')
-          pip uninstall probeinterface --yes
-          git clone https://github.com/spikeinterface/probeinterface ./probeinterface
-          cd probeinterface
-          git fetch
-          git checkout tags/$PROBEINTERFACE_VERSION
-          cd ..
-          pip install ./probeinterface
+          PROBEINTERFACE_VERSION=$(git ls-remote --tags --refs --sort=-v:refname https://github.com/spikeinterface/probeinterface | head -n 1 | sed 's|.*refs/tags/||')
+          echo "Cloning probeinterface $PROBEINTERFACE_VERSION"
+          git clone --depth 1 --branch "$PROBEINTERFACE_VERSION" https://github.com/spikeinterface/probeinterface ./probeinterface
+          pip install ./probeinterface matplotlib
 
 
       - name: Generate full NP library and check for changes

--- a/.github/workflows/check_for_new_NP_probes.yml
+++ b/.github/workflows/check_for_new_NP_probes.yml
@@ -24,10 +24,12 @@ jobs:
         with:
           python-version: '3.10' 
 
-      #  Clone dev version of probeinterface
+      #  Clone the latest released version of probeinterface
       - name: Clone external repository
         run: |
-          git clone https://github.com/spikeinterface/probeinterface ./probeinterface
+          PROBEINTERFACE_VERSION=$(git ls-remote --tags --refs --sort=-v:refname https://github.com/spikeinterface/probeinterface | head -n 1 | sed 's|.*refs/tags/||')
+          echo "Cloning probeinterface $PROBEINTERFACE_VERSION"
+          git clone --depth 1 --branch "$PROBEINTERFACE_VERSION" https://github.com/spikeinterface/probeinterface ./probeinterface
 
       - name: Install probeinterface and matplotlib
         run: pip install ./probeinterface matplotlib

--- a/.github/workflows/generate_cambridge_neurotech_library.yml
+++ b/.github/workflows/generate_cambridge_neurotech_library.yml
@@ -24,11 +24,13 @@ jobs:
         with:
           python-version: '3.10' 
 
-      #  Clone dev version of probeinterface
+      #  Clone the latest released version of probeinterface
       - name: Clone external repositories
         run: |
           # probeinterface
-          git clone https://github.com/spikeinterface/probeinterface ./probeinterface
+          PROBEINTERFACE_VERSION=$(git ls-remote --tags --refs --sort=-v:refname https://github.com/spikeinterface/probeinterface | head -n 1 | sed 's|.*refs/tags/||')
+          echo "Cloning probeinterface $PROBEINTERFACE_VERSION"
+          git clone --depth 1 --branch "$PROBEINTERFACE_VERSION" https://github.com/spikeinterface/probeinterface ./probeinterface
 
           # cambridge neurotech probe maps
           git clone https://github.com/cambridge-neurotech/probe_maps.git ./probe_maps

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,16 @@ import jsonschema
 import pytest
 import requests
 
-schema_url = "https://raw.githubusercontent.com/SpikeInterface/probeinterface/main/src/probeinterface/schema/probe.json.schema"
+# Validate against the schema of the latest *released* probeinterface, not main:
+# the catalog is meant to be readable by the version users actually install.
+pypi_response = requests.get("https://pypi.org/pypi/probeinterface/json")
+pypi_response.raise_for_status()
+probeinterface_version = pypi_response.json()["info"]["version"]
+
+schema_url = (
+    f"https://raw.githubusercontent.com/SpikeInterface/probeinterface/{probeinterface_version}/"
+    "src/probeinterface/schema/probe.json.schema"
+)
 
 response = requests.get(schema_url)
 response.raise_for_status()


### PR DESCRIPTION
This PR changes the actions and the schema to use the latest probeinterface release. We need a new probeinterface release before accepting this because the contact_sides is not in the latest release...so keeping as draft for now